### PR TITLE
Avoid Inf Loop in Joint Tour Participation

### DIFF
--- a/activitysim/abm/models/joint_tour_participation.py
+++ b/activitysim/abm/models/joint_tour_participation.py
@@ -209,6 +209,10 @@ def participants_chooser(probs, choosers, spec, trace_label):
                 probs[choice_col] = np.where(probs[choice_col] > 0, 1, 0)
                 non_choice_col = [col for col in probs.columns if col != choice_col][0]
                 probs[non_choice_col] = 1 - probs[choice_col]
+                if iter > MAX_ITERATIONS + 1:
+                    raise RuntimeError(
+                        f"{num_tours_remaining} tours could not be satisfied even with forcing participation"
+                    )
             else:
                 raise RuntimeError(
                     f"{num_tours_remaining} tours could not be satisfied after {iter} iterations"


### PR DESCRIPTION
The joint tour participation model works by assigning probabilities for each person in the household as to whether they participate in a joint tour.  The model then tries to satisfy the composition of the joint tour by iteratively drawing random numbers and seeing if each person participates.  Sometimes the probabilities are very small, and the joint tour participation model runs out of iterations.  The user has an option to specify to force participation after the specified number of iterations for anyone with a non-zero probability.  

However, if forced participation still does not satisfy tour composition, the model is stuck in an infinite loop trying to force satisfaction even though its impossible. (Only ran into this in fringe cases in estimation mode.)

This PR will throw a runtime error if the forced participation is still unsuccessful at satisfying all joint tours.