### PR TITLE
Further parking location fix update

### DIFF
--- a/activitysim/abm/models/trip_matrices.py
+++ b/activitysim/abm/models/trip_matrices.py
@@ -246,12 +246,13 @@ def write_trip_matrices(network_los):
         trips_df["destination"] = trips_df["true_destination"]
         del trips_df["true_origin"], trips_df["true_destination"]
 
-        trips_df["otaz"] = (
-            pipeline.get_table("land_use").reindex(trips_df["origin"]).TAZ.tolist()
-        )
-        trips_df["dtaz"] = (
-            pipeline.get_table("land_use").reindex(trips_df["destination"]).TAZ.tolist()
-        )
+        if network_los.zone_system == los.TWO_ZONE or network_los.zone_system == los.THREE_ZONE:
+            trips_df["otaz"] = (
+                pipeline.get_table("land_use").reindex(trips_df["origin"]).TAZ.tolist()
+            )
+            trips_df["dtaz"] = (
+                pipeline.get_table("land_use").reindex(trips_df["destination"]).TAZ.tolist()
+            )
 
 
 def annotate_trips(trips, network_los, model_settings):

--- a/activitysim/abm/models/trip_matrices.py
+++ b/activitysim/abm/models/trip_matrices.py
@@ -51,15 +51,8 @@ def write_trip_matrices(network_los):
     if "parking_location" in config.setting("models"):
         parking_settings = config.read_model_settings("parking_location_choice.yaml")
         parking_taz_col_name = parking_settings["ALT_DEST_COL_NAME"]
-        auto_nest_name = parking_settings["AUTO_MODE_NEST"]
-
-        # Read trip mode choice settings to get auto modes
-        trip_mode_choice_settings = config.read_model_settings("trip_mode_choice.yaml")
-        trip_mode_choice_nest = config.get_logit_mocel_settings(trip_mode_choice_settings)
-        for alternative in trip_mode_choice_nest["alternatives"]:
-            if alternative["name"] == auto_nest_name:
-                auto_modes = alternative["alternatives"]
-                break
+        assert "AUTO_MODES" in parking_settings, "AUTO_MODES must be specified in parking location settings to properly adjust trip tables for assignment"
+        auto_modes = parking_settings["AUTO_MODES"]
 
         if parking_taz_col_name in trips_df:
             

--- a/activitysim/abm/models/trip_matrices.py
+++ b/activitysim/abm/models/trip_matrices.py
@@ -246,6 +246,13 @@ def write_trip_matrices(network_los):
         trips_df["destination"] = trips_df["true_destination"]
         del trips_df["true_origin"], trips_df["true_destination"]
 
+        trips_df["otaz"] = (
+            pipeline.get_table("land_use").reindex(trips_df["origin"]).TAZ.tolist()
+        )
+        trips_df["dtaz"] = (
+            pipeline.get_table("land_use").reindex(trips_df["destination"]).TAZ.tolist()
+        )
+
 
 def annotate_trips(trips, network_los, model_settings):
     """


### PR DESCRIPTION
My previous fix adjusted the origin TAZ for trips following those that ended at a parking destination other than the trip destination so that the origin of the next trip was the zone where the vehicle was parked in in order to make traffic assignment more accurate, as prior to that fix vehicles were effectively teleporting from the parking location to the trip origin. However, this did not check to see if the subsequent trip was also made by auto, resulting in non-auto trips that being at the previous trip's parking location, which will have a slight impact on transit assignment. This pull request changes the code to open the trip mode choice spec, look up what the auto modes are, and only adjust the origin TAZ if the trip is made by an auto mode. It should be noted that there will still be "teleporting vehicles" if a person uses a parking location other than their destination and then goes on an atwork subtour using a non-auto mode, but that is expected to be less common and have only a minor impact on model results.

There are also a couple of additional lines so that the origin and destination TAZs reported in final_trips always match the origin and destination MAZs.