### PR TITLE
Load skims into shared memory to be accessed by later models

### DIFF
--- a/activitysim/core/mem.py
+++ b/activitysim/core/mem.py
@@ -296,6 +296,9 @@ def shared_memory_size(data_buffers=None):
 
             shared_size += Dataset.shm.preload_shared_memory_size(data_buffer[11:])
             continue
+        if isinstance(data_buffer, multiprocessing.shared_memory.SharedMemory):
+            shared_size += data_buffer.size
+            continue
         try:
             obj = data_buffer.get_obj()
         except Exception:

--- a/activitysim/core/skim_dict_factory.py
+++ b/activitysim/core/skim_dict_factory.py
@@ -409,19 +409,26 @@ class NumpyArraySkimFactory(AbstractSkimFactory):
             f"total size: {util.INT(csz)} ({util.GB(csz)})"
         )
 
-        if shared:
-            if dtype_name == "float64":
-                typecode = "d"
-            elif dtype_name == "float32":
-                typecode = "f"
-            else:
-                raise RuntimeError(
-                    "allocate_skim_buffer unrecognized dtype %s" % dtype_name
-                )
+        # if shared:
+            # if dtype_name == "float64":
+            #     typecode = "d"
+            # elif dtype_name == "float32":
+            #     typecode = "f"
+            # else:
+            #     raise RuntimeError(
+            #         "allocate_skim_buffer unrecognized dtype %s" % dtype_name
+            #     )
 
-            buffer = multiprocessing.RawArray(typecode, buffer_size)
-        else:
-            buffer = np.zeros(buffer_size, dtype=dtype)
+            # buffer = multiprocessing.RawArray(typecode, buffer_size)
+        shared_mem_name = f"skim_shared_memory__{skim_info.skim_tag}"
+        try:
+            buffer = multiprocessing.shared_memory.SharedMemory(name=shared_mem_name)
+            logger.info(f"skim buffer already allocated in shared memory: {shared_mem_name}, size: {buffer.size}")
+        except FileNotFoundError:
+            buffer = multiprocessing.shared_memory.SharedMemory(create=True, size=csz, name=shared_mem_name)
+            logger.info(f"allocating skim buffer in shared memory: {shared_mem_name}, size: {buffer.size}")
+        # else:
+        #     buffer = np.zeros(buffer_size, dtype=dtype)
 
         return buffer
 
@@ -440,8 +447,9 @@ class NumpyArraySkimFactory(AbstractSkimFactory):
         """
 
         dtype = np.dtype(skim_info.dtype_name)
-        assert len(skim_buffer) == util.iprod(skim_info.skim_data_shape)
-        skim_data = np.frombuffer(skim_buffer, dtype=dtype).reshape(
+        # assert len(skim_buffer) == util.iprod(skim_info.skim_data_shape)
+        assert skim_buffer.size >= util.iprod(skim_info.skim_data_shape) * dtype.itemsize
+        skim_data = np.frombuffer(skim_buffer.buf, dtype=dtype, count=util.iprod(skim_info.skim_data_shape)).reshape(
             skim_info.skim_data_shape
         )
         return skim_data
@@ -461,6 +469,9 @@ class NumpyArraySkimFactory(AbstractSkimFactory):
 
         skim_data = self._skim_data_from_buffer(skim_info, skim_buffer)
         assert skim_data.shape == skim_info.skim_data_shape
+
+        if skim_data.any():
+            return
 
         if read_cache:
             # returns None if cache file not found


### PR DESCRIPTION
Skims are loaded as a multiprocessing.shared_memory.SharedMemory buffer. Will only load skims from OMX if buffer does not already exist in shared memory. When used with an external script to hold onto shared memory, this allows skims to be kept in memory between models.

An additional improvement could be to add a GUID to the shared memory name as a failsafe to ensure the shared memory buffer is only usable by the current run. This GUID could potentially be set in network_los.yaml.

Currently, these changes cause ActivitySim to crash when running with multiprocessing disabled. I am still investigating this issue. I could disable this functionality when running single-processed for now, but this would create two copies of the skims in memory when running a single-processed model after a multi-processed model.